### PR TITLE
相対パスでのファイル指定が動作しない問題を修正

### DIFF
--- a/clnch_commandline.py
+++ b/clnch_commandline.py
@@ -160,6 +160,9 @@ class commandline_ExecuteFile:
         
         directory, tmp = ckit.splitPath(file)
     
+        if not os.path.isabs(file):
+            file = os.path.abspath(file)
+
         #print( "File: %s" % ( file, ) )
         #print( "      %s" % ( joint_args, ) )
 


### PR DESCRIPTION
相対パスでファイルを入力したときに次のようなエラーが発生していた。

```
FileNotFoundError: [WinError 2] 指定されたファイルが見つかりません。
```

例えば、 `.\doc\index.html` を入力したときには `commandline_ExecuteFile.onEnter()` において、
- `file`:      `.\doc\index.html`
- `directory`: `.\doc`

となるので、`pyauto.shellExecute( None, file, joint_args, directory )` を実行すると、`.\doc\doc\index.html` を開こうとしてしまっていた。

そのため、`file` を絶対パスに変換してから `pyauto.shellExecute()` に渡すように修正した。
